### PR TITLE
Playable cards bugfix

### DIFF
--- a/app/src/main/java/com/github/lucaengel/jass_entials/data/cards/PlayerData.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/data/cards/PlayerData.kt
@@ -44,6 +44,12 @@ data class PlayerData(
             ?.card
             ?: return cards // no card has been played yet --> can play any card
 
+        // cards of the suit of the first card played
+        val firstCardSuitCards = cardsOfSuit(firstCard.suit)
+        // if the player does not have any cards of the suit of the first card played, they can play any card
+        if (firstCardSuitCards.isEmpty())
+            return cards
+
         val trumpSuit = Trump.asSuit(trump)
 
         // get trump cards (null if trump was unger ufe or obe abe)
@@ -53,15 +59,23 @@ data class PlayerData(
             listOf()
         }
 
-        // cards of the suit of the first card played
-        val firstCardSuitCards = cardsOfSuit(firstCard.suit)
+
         // no under trumping (ungertrumpfe) possible
         val playableTrumpCards = playableTrumpCards(trumpCards, trick, trumpSuit)
 
         val playableCards = (firstCardSuitCards + playableTrumpCards).distinct()
 
+        // if the player only has one card left and it is a jack of trump, they can play any card
+        // as you are allowed to keep the jack of trump even if you could play it as long as you have other cards
+        if (playableCards.size == 1
+            && trumpSuit != null
+            && playableCards.first() == Card(Rank.JACK, trumpSuit)) {
+            return cards
+        }
+
+        // no empty check needed since we already checked if
+        // the player has cards of the suit of the first card played
         return playableCards
-            .ifEmpty { cards }
     }
 
     /**

--- a/app/src/test/java/com/github/lucaengel/jass_entials/data/cards/PlayerDataTest.kt
+++ b/app/src/test/java/com/github/lucaengel/jass_entials/data/cards/PlayerDataTest.kt
@@ -275,4 +275,116 @@ class PlayerDataTest {
             *player.cards.toTypedArray()
         ))
     }
+
+    @Test
+    fun trumpJackDoesNotHaveToBePlayedWhenTrumpIsOutAndJackIsTheOnlyTrumpCard() {
+        val player = defaultPlayerData.copy(cards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+
+            Card(Rank.ACE, Suit.SPADES),
+            Card(Rank.SEVEN, Suit.SPADES),
+            Card(Rank.SIX, Suit.SPADES),
+
+            Card(Rank.JACK, Suit.CLUBS),
+        ))
+
+        val trick = Trick(listOf(
+            Trick.TrickCard(Card(Rank.TEN, Suit.CLUBS), "email_1"),
+            Trick.TrickCard(Card(Rank.TEN, Suit.DIAMONDS), "email_2"),
+        ))
+
+        val playableCards = player.playableCards(trick, Trump.CLUBS)
+
+        // All cards should be able to be played since the current player only has the trump jack
+        // of the trump suit that is out
+        assertThat(playableCards, Matchers.containsInAnyOrder(
+            *player.cards.toTypedArray()
+        ))
+    }
+
+    @Test
+    fun playerMustPlayTheJackIfItIsTheOnlyCardToHoldSuitWithAndItIsNotTrump() {
+        val player = defaultPlayerData.copy(cards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+
+            Card(Rank.ACE, Suit.SPADES),
+            Card(Rank.SEVEN, Suit.SPADES),
+            Card(Rank.SIX, Suit.SPADES),
+
+            Card(Rank.JACK, Suit.CLUBS),
+        ))
+
+        val trick = Trick(listOf(
+            Trick.TrickCard(Card(Rank.TEN, Suit.CLUBS), "email_1"),
+            Trick.TrickCard(Card(Rank.TEN, Suit.DIAMONDS), "email_2"),
+        ))
+
+        val playableCards = player.playableCards(trick, Trump.UNGER_UFE)
+
+        // All cards should be able to be played since the current player only has the trump jack
+        // of the trump suit that is out
+        assertThat(playableCards, Matchers.containsInAnyOrder(
+            Card(Rank.JACK, Suit.CLUBS)
+        ))
+    }
+
+    @Test
+    fun playerMustHoldSuitIfTheyCanAndTheyHaveNoTrumpCards() {
+        val player = defaultPlayerData.copy(cards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+
+            Card(Rank.ACE, Suit.SPADES),
+            Card(Rank.SEVEN, Suit.SPADES),
+            Card(Rank.SIX, Suit.SPADES),
+
+            Card(Rank.TEN, Suit.CLUBS),
+        ))
+
+        val trick = Trick(listOf(
+            Trick.TrickCard(Card(Rank.TEN, Suit.CLUBS), "email_1"),
+            Trick.TrickCard(Card(Rank.TEN, Suit.DIAMONDS), "email_2"),
+        ))
+
+        val playableCards = player.playableCards(trick, Trump.CLUBS)
+
+        // All cards should be able to be played since the current player only has the trump jack
+        // of the trump suit that is out
+        assertThat(playableCards, Matchers.containsInAnyOrder(
+            Card(Rank.TEN, Suit.CLUBS)
+        ))
+    }
+
+    @Test
+    fun allCardsArePlayableIfASuitIsOutThatThePlayerDoesNotHaveAndThePlayerHasTrumpAndNonTrumpCards() {
+        val player = defaultPlayerData.copy(cards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+
+            Card(Rank.ACE, Suit.SPADES),
+            Card(Rank.SEVEN, Suit.SPADES),
+            Card(Rank.SIX, Suit.SPADES),
+
+            Card(Rank.JACK, Suit.CLUBS),
+            Card(Rank.TEN, Suit.CLUBS),
+        ))
+
+        val trick = Trick(listOf(
+            Trick.TrickCard(Card(Rank.TEN, Suit.DIAMONDS), "email_2"),
+            Trick.TrickCard(Card(Rank.TEN, Suit.CLUBS), "email_1"),
+        ))
+
+        val playableCards = player.playableCards(trick, Trump.CLUBS)
+
+        // All cards should be able to be played since the current player does not have any diamonds
+        assertThat(playableCards, Matchers.containsInAnyOrder(
+            *player.cards.toTypedArray()
+        ))
+    }
 }

--- a/app/src/test/java/com/github/lucaengel/jass_entials/data/cards/PlayerDataTest.kt
+++ b/app/src/test/java/com/github/lucaengel/jass_entials/data/cards/PlayerDataTest.kt
@@ -3,7 +3,9 @@ package com.github.lucaengel.jass_entials.data.cards
 import com.github.lucaengel.jass_entials.data.jass.Trump
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
+import org.junit.Assert.assertThrows
 import org.junit.Test
+import java.lang.IllegalStateException
 
 class PlayerDataTest {
 
@@ -386,5 +388,47 @@ class PlayerDataTest {
         assertThat(playableCards, Matchers.containsInAnyOrder(
             *player.cards.toTypedArray()
         ))
+    }
+    @Test
+    fun withCaredPlayedReturnsPlayerWithoutTheGivenCard() {
+        val expectedCards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+
+            Card(Rank.ACE, Suit.SPADES),
+            Card(Rank.SEVEN, Suit.SPADES),
+            Card(Rank.SIX, Suit.SPADES),
+
+            Card(Rank.JACK, Suit.CLUBS),
+            Card(Rank.TEN, Suit.CLUBS),
+            )
+        val cardToPlay = Card(Rank.TEN, Suit.DIAMONDS)
+
+        val player = defaultPlayerData.copy(cards = listOf(
+            *expectedCards.toTypedArray(),
+            cardToPlay,
+        ))
+        val newPlayer = player.withCardPlayed(cardToPlay)
+
+        assertThat(newPlayer.cards, Matchers.containsInAnyOrder(
+            *expectedCards.toTypedArray()
+        ))
+    }
+
+    @Test
+    fun withCardPlayedThrowsIfTheCardIsNotInThePlayersHand() {
+
+        val inExistentCard = Card(Rank.TEN, Suit.DIAMONDS)
+
+        val player = defaultPlayerData.copy(cards = listOf(
+            Card(Rank.TEN, Suit.HEARTS),
+            Card(Rank.SIX, Suit.HEARTS),
+            Card(Rank.NINE, Suit.HEARTS),
+        ))
+
+        assertThrows(IllegalStateException::class.java) {
+            player.withCardPlayed(inExistentCard)
+        }
     }
 }


### PR DESCRIPTION
Bugs fixed:
- trump jack can be held back (not possible before)
- if no card of the suit of the first played card, any card can be played (before, only trump cards were allowed)