### PR TITLE
Upgrade to gradle 8

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,6 +7,10 @@ container:
 env:
   CC_TEST_REPORTER_ID: ENCRYPTED[!942125cb3ea65a81b33ed29fae738238f9060dfe3594af3e63b76f040c72b321905507ae5822965c7b031109cf07e3c8!]
 
+Install_Java_17:
+  sudo apt-get update
+  sudo apt-get install -y openjdk-17-jdk
+
 check_android_task:
   name: Run Android tests
   install_emulator_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,14 +7,16 @@ container:
 env:
   CC_TEST_REPORTER_ID: ENCRYPTED[!942125cb3ea65a81b33ed29fae738238f9060dfe3594af3e63b76f040c72b321905507ae5822965c7b031109cf07e3c8!]
 
-Install_Java_17:
-  sudo apt-get update
-  sudo apt-get install -y openjdk-17-jdk
-
 check_android_task:
   name: Run Android tests
   install_emulator_script:
     sdkmanager --install "system-images;android-30;google_apis_playstore;x86"
+
+  install_java_17_script:
+    sudo apt-get update
+    sudo apt-get install -y openjdk-17-jdk
+
+
   create_avd_script:
     echo no | avdmanager create avd --force
     --name emulator

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,68 +1,68 @@
-container:
-  image: cirrusci/android-sdk:33
-  cpu: 4
-  memory: 16G
-  kvm: true
+  container:
+    image: cirrusci/android-sdk:30
+    cpu: 4
+    memory: 16G
+    kvm: true
 
-env:
-  CC_TEST_REPORTER_ID: ENCRYPTED[!942125cb3ea65a81b33ed29fae738238f9060dfe3594af3e63b76f040c72b321905507ae5822965c7b031109cf07e3c8!]
+  env:
+    CC_TEST_REPORTER_ID: ENCRYPTED[!942125cb3ea65a81b33ed29fae738238f9060dfe3594af3e63b76f040c72b321905507ae5822965c7b031109cf07e3c8!]
 
-check_android_task:
-  name: Run Android tests
-  install_emulator_script:
-    sdkmanager --install "system-images;android-30;google_apis_playstore;x86"
+  check_android_task:
+    name: Run Android tests
+    install_emulator_script:
+      sdkmanager --install "system-images;android-30;google_apis_playstore;x86"
 
-  install_java_17_script:
-    - sudo apt-get update
-    - sudo apt-get install -y openjdk-17-jdk
-  create_avd_script:
-    echo no | avdmanager create avd --force
-    --name emulator
-    --package "system-images;android-30;google_apis_playstore;x86"
-  start_avd_background_script:
-    $ANDROID_HOME/emulator/emulator
-    -avd emulator
-    -no-audio
-    -no-boot-anim
-    -gpu swiftshader_indirect
-    -no-snapshot
-    -no-window
-    -camera-back none
-  assemble_instrumented_tests_script: |
-    chmod +x gradlew
-    ./gradlew assembleDebugAndroidTest
-  wait_for_avd_script:
-    adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 3; done; input keyevent 82'
-  disable_animations_script: |
-    adb shell settings put global window_animation_scale 0.0
-    adb shell settings put global transition_animation_scale 0.0
-    adb shell settings put global animator_duration_scale 0.0
-  prepare_codeclimate_script: |
-    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-    chmod +x ./cc-test-reporter
-    ./cc-test-reporter before-build
-  screen_record_background_script:
-    for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
-  check_script:
-    ./gradlew check connectedCheck
-  report_codeclimate_script: |
-    export JACOCO_SOURCE_PATH=app/src/main/java/
-    ./cc-test-reporter format-coverage ./app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml --input-type jacoco
-    ./cc-test-reporter upload-coverage
-  lint_script:
-    ./gradlew lintDebug
-  always:
-    wait_for_screenrecord_script: |
-      pkill -2 -x adb
-      sleep 2
-    screenrecord_artifacts:
-      path: "*.h264"
-    android_lint_artifacts:
-      path: ./app/build/reports/lint-results-debug.xml
-      format: android-lint
-    test_artifacts:
-      path: "./app/build/test-results/**/*.xml"
-      format: junit
-    androidtest_artifacts:
-      path: "./app/build/outputs/**/*.xml"
-      format: junit
+    install_java_17_script:
+      - sudo apt-get update
+      - sudo apt-get install -y openjdk-17-jdk
+    create_avd_script:
+      echo no | avdmanager create avd --force
+      --name emulator
+      --package "system-images;android-30;google_apis_playstore;x86"
+    start_avd_background_script:
+      $ANDROID_HOME/emulator/emulator
+      -avd emulator
+      -no-audio
+      -no-boot-anim
+      -gpu swiftshader_indirect
+      -no-snapshot
+      -no-window
+      -camera-back none
+    assemble_instrumented_tests_script: |
+      chmod +x gradlew
+      ./gradlew assembleDebugAndroidTest
+    wait_for_avd_script:
+      adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 3; done; input keyevent 82'
+    disable_animations_script: |
+      adb shell settings put global window_animation_scale 0.0
+      adb shell settings put global transition_animation_scale 0.0
+      adb shell settings put global animator_duration_scale 0.0
+    prepare_codeclimate_script: |
+      curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      chmod +x ./cc-test-reporter
+      ./cc-test-reporter before-build
+    screen_record_background_script:
+      for n in $(seq 1 20); do adb exec-out screenrecord --time-limit=180 --output-format=h264 - > $n.h264; done
+    check_script:
+      ./gradlew check connectedCheck
+    report_codeclimate_script: |
+      export JACOCO_SOURCE_PATH=app/src/main/java/
+      ./cc-test-reporter format-coverage ./app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml --input-type jacoco
+      ./cc-test-reporter upload-coverage
+    lint_script:
+      ./gradlew lintDebug
+    always:
+      wait_for_screenrecord_script: |
+        pkill -2 -x adb
+        sleep 2
+      screenrecord_artifacts:
+        path: "*.h264"
+      android_lint_artifacts:
+        path: ./app/build/reports/lint-results-debug.xml
+        format: android-lint
+      test_artifacts:
+        path: "./app/build/test-results/**/*.xml"
+        format: junit
+      androidtest_artifacts:
+        path: "./app/build/outputs/**/*.xml"
+        format: junit

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: cirrusci/android-sdk:30
+  image: cirrusci/android-sdk:33
   cpu: 4
   memory: 16G
   kvm: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,6 @@ check_android_task:
     - sudo apt-get update
     - sudo apt-get install -y openjdk-17-jdk
 
-
   create_avd_script:
     echo no | avdmanager create avd --force
     --name emulator

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,6 @@ check_android_task:
   install_java_17_script:
     - sudo apt-get update
     - sudo apt-get install -y openjdk-17-jdk
-
   create_avd_script:
     echo no | avdmanager create avd --force
     --name emulator

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,8 +13,8 @@ check_android_task:
     sdkmanager --install "system-images;android-30;google_apis_playstore;x86"
 
   install_java_17_script:
-    sudo apt-get update
-    sudo apt-get install -y openjdk-17-jdk
+    - sudo apt-get update
+    - sudo apt-get install -y openjdk-17-jdk
 
 
   create_avd_script:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,11 +32,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.1' apply false
-    id 'com.android.library' version '7.4.1' apply false
+    id 'com.android.application' version '8.1.1' apply false
+    id 'com.android.library' version '8.1.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,5 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false


### PR DESCRIPTION
This PR upgrades the project to use gradle 8 (before it was 7)  which enables more features when developing.

To allow for this upgrade, the java version of the application needed to be changed to java 17 as java 11 is not compatible with gradle 8. Therefore, on cirrus ci, now always java 17 is downloaded when running the ci to still have the tests run and test coverage reported to codeclimate