### PR TITLE
CoiffeurPostRoundActivity: Table layout for the scores and adapt final score to use multiplication factor

### DIFF
--- a/app/src/androidTest/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivityTest.kt
+++ b/app/src/androidTest/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivityTest.kt
@@ -1,0 +1,131 @@
+package com.github.lucaengel.jass_entials.game.postgame
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.lucaengel.jass_entials.data.game_state.Bet
+import com.github.lucaengel.jass_entials.data.game_state.BetHeight
+import com.github.lucaengel.jass_entials.data.game_state.GameStateHolder
+import com.github.lucaengel.jass_entials.data.game_state.PlayerId
+import com.github.lucaengel.jass_entials.data.game_state.Score
+import com.github.lucaengel.jass_entials.data.jass.Trump
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.Thread.sleep
+
+@RunWith(AndroidJUnit4::class)
+class CoiffeurPostRoundActivityTest {
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    private val defaultIntent = Intent(ApplicationProvider.getApplicationContext(), CoiffeurPostRoundActivity::class.java)
+
+
+    @Before
+    fun setUp() {
+        GameStateHolder.prevRoundScores = listOf()
+    }
+
+    @After
+    fun tearDown() {
+        sleep(1000)
+    }
+
+    @Test
+    fun correctInitialScreenContent() {
+        GameStateHolder.prevRoundScores = listOf(
+            Pair(Bet(PlayerId.PLAYER_1, Trump.CLUBS, BetHeight.MATCH), Score(100, 57, 100, 57)),
+            Pair(Bet(PlayerId.PLAYER_3, Trump.UNGER_UFE, BetHeight.MATCH), Score(110, 47, 110, 47)),
+
+            Pair(Bet(PlayerId.PLAYER_2, Trump.DIAMONDS, BetHeight.MATCH), Score(77, 80, 77, 80)),
+            Pair(Bet(PlayerId.PLAYER_4, Trump.HEARTS, BetHeight.MATCH), Score(72, 85, 72, 85)),
+        )
+
+        ActivityScenario.launch<PostRoundActivity>(defaultIntent).use {
+            Intents.init()
+
+            for (trump in Trump.values()) {
+                composeTestRule.onNodeWithContentDescription(trump.toString(), useUnmergedTree = true)
+                    .assertExists()
+            }
+
+            composeTestRule.onNodeWithText("100", useUnmergedTree = true)
+                .assertExists()
+            composeTestRule.onNodeWithText("110", useUnmergedTree = true)
+                .assertExists()
+            composeTestRule.onNodeWithText("80", useUnmergedTree = true)
+                .assertExists()
+            composeTestRule.onNodeWithText("85", useUnmergedTree = true)
+                .assertExists()
+
+            // total score:
+            composeTestRule.onNodeWithText("210", useUnmergedTree = true)
+                .assertExists()
+            composeTestRule.onNodeWithText("165", useUnmergedTree = true)
+                .assertExists()
+
+
+            composeTestRule.onNodeWithText("Start next round", useUnmergedTree = true)
+                .assertExists()
+
+            Intents.release()
+        }
+    }
+
+    @Test
+    fun whenGameIsOverUserCanGoToSelectGameActivity() {
+        var pointsTeam1 = 0
+        var pointsTeam2: Int
+        var gamePointsTeam1 = 0
+        var gamePointsTeam2 = 0
+        GameStateHolder.prevRoundScores = Trump.values().map {trump ->
+            listOf(
+                Pair(Bet(PlayerId.PLAYER_1, trump, BetHeight.MATCH), Score(
+                    pointsTeam1.let { pointsTeam1 =  100 + trump.ordinal; gamePointsTeam1 += pointsTeam1; pointsTeam2 = 157 - pointsTeam1; gamePointsTeam2 += pointsTeam2; pointsTeam1},
+                    pointsTeam2,
+                    gamePointsTeam1,
+                    gamePointsTeam2)),
+                Pair(Bet(PlayerId.PLAYER_2, trump, BetHeight.MATCH), Score(
+                    pointsTeam2.let { pointsTeam2 =  80 + trump.ordinal; gamePointsTeam2 += pointsTeam2; pointsTeam1 = 157 - pointsTeam2; gamePointsTeam1 += pointsTeam1; pointsTeam1},
+                    pointsTeam2,
+                    gamePointsTeam1,
+                    gamePointsTeam2)),
+            )
+        }.flatten()
+
+        GameStateHolder.gameState = GameStateHolder.gameState.copy(
+            roundState = GameStateHolder.gameState.roundState.copy(
+                score = GameStateHolder.prevRoundScores.last().second
+            )
+        )
+
+        ActivityScenario.launch<PostRoundActivity>(defaultIntent).use {
+            Intents.init()
+
+            composeTestRule.onNodeWithText("The game is over, ${PlayerId.PLAYER_1.teamId()} won!", useUnmergedTree = true)
+                .assertExists()
+
+            // Total score
+            composeTestRule.onNodeWithText("${6*100 + 1+2+3+4+5}", useUnmergedTree = true)
+                .assertExists()
+            composeTestRule.onNodeWithText("${6*80 + 1+2+3+4+5}", useUnmergedTree = true)
+                .assertExists()
+
+            composeTestRule.onNodeWithText("Choose a new Jass game", useUnmergedTree = true)
+                .assertExists()
+                .performClick()
+
+            Intents.release()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivityTest.kt
+++ b/app/src/androidTest/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivityTest.kt
@@ -69,9 +69,9 @@ class CoiffeurPostRoundActivityTest {
                 .assertExists()
 
             // total score:
-            composeTestRule.onNodeWithText("210", useUnmergedTree = true)
+            composeTestRule.onNodeWithText("${100 * (Trump.CLUBS.ordinal + 1) + 110 * (Trump.UNGER_UFE.ordinal + 1)}", useUnmergedTree = true)
                 .assertExists()
-            composeTestRule.onNodeWithText("165", useUnmergedTree = true)
+            composeTestRule.onNodeWithText("${80 * (Trump.DIAMONDS.ordinal + 1) + 85 * (Trump.HEARTS.ordinal + 1)}", useUnmergedTree = true)
                 .assertExists()
 
 
@@ -116,9 +116,9 @@ class CoiffeurPostRoundActivityTest {
                 .assertExists()
 
             // Total score
-            composeTestRule.onNodeWithText("${6*100 + 1+2+3+4+5}", useUnmergedTree = true)
+            composeTestRule.onNodeWithText("${21*100 + 1*2 + 2*3 + 3*4 + 4*5 + 5*6}", useUnmergedTree = true)
                 .assertExists()
-            composeTestRule.onNodeWithText("${6*80 + 1+2+3+4+5}", useUnmergedTree = true)
+            composeTestRule.onNodeWithText("${21*80 + 1*2 + 2*3 + 3*4 + 4*5 + 5*6}", useUnmergedTree = true)
                 .assertExists()
 
             composeTestRule.onNodeWithText("Choose a new Jass game", useUnmergedTree = true)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,12 @@
             android:label="SidiBarrani Postgame Activity"
             android:theme="@style/Theme.Jassentials" >
         </activity>
+        <activity
+            android:name=".game.postgame.CoiffeurPostRoundActivity"
+            android:exported="true"
+            android:label="SidiBarrani Postgame Activity"
+            android:theme="@style/Theme.Jassentials" >
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/github/lucaengel/jass_entials/data/game_state/GameStateHolder.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/data/game_state/GameStateHolder.kt
@@ -107,6 +107,11 @@ class GameStateHolder {
          */
         var prevTrumpsByTeam = mapOf<TeamId, Set<Trump>>()
 
+        /**
+         * The RoundStates of the previous rounds of the current game.
+         */
+        var prevRoundScores = listOf<Pair<Bet, Score>>()
+
 //        /**
 //         * The cards that are guaranteed to be in the hands of the given players.
 //         */
@@ -167,6 +172,8 @@ class GameStateHolder {
 //                jassType = jassType,
                 score = gameState.roundState.score().nextRound(),
             )
+
+            prevRoundScores = prevRoundScores + Pair(gameState.winningBet, gameState.roundState.score())
         }
     }
 }

--- a/app/src/main/java/com/github/lucaengel/jass_entials/data/game_state/GameStateHolder.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/data/game_state/GameStateHolder.kt
@@ -172,8 +172,6 @@ class GameStateHolder {
 //                jassType = jassType,
                 score = gameState.roundState.score().nextRound(),
             )
-
-            prevRoundScores = prevRoundScores + Pair(gameState.winningBet, gameState.roundState.score())
         }
     }
 }

--- a/app/src/main/java/com/github/lucaengel/jass_entials/data/jass/Trump.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/data/jass/Trump.kt
@@ -38,16 +38,16 @@ enum class Trump {
         }
     }
 
-//    override fun toString(): String {
-//        return when (this) {
-//            DIAMONDS -> Suit.DIAMONDS.symbol()
-//            HEARTS -> Suit.HEARTS.symbol()
-//            SPADES -> Suit.SPADES.symbol()
-//            CLUBS -> Suit.CLUBS.symbol()
-//            UNGER_UFE -> "\u2191"
-//            OBE_ABE -> "\u2193"
-//        }
-//    }
+    override fun toString(): String {
+        return when (this) {
+            DIAMONDS -> Suit.DIAMONDS.symbol()
+            HEARTS -> Suit.HEARTS.symbol()
+            SPADES -> Suit.SPADES.symbol()
+            CLUBS -> Suit.CLUBS.symbol()
+            UNGER_UFE -> "\u2191"
+            OBE_ABE -> "\u2193"
+        }
+    }
 
     fun asSuit(): Suit? {
         return Trump.asSuit(this)

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/JassRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/JassRoundActivity.kt
@@ -97,6 +97,8 @@ fun JassRound() {
             // Store current game state
             GameStateHolder.gameState = gameState
             GameStateHolder.players = players
+            GameStateHolder.prevRoundScores = GameStateHolder.prevRoundScores + Pair(gameState.winningBet, gameState.roundState.score())
+
 
             val postGameActivity = if (gameState.jassType == JassType.COIFFEUR) {
                 Intent(context, CoiffeurPostRoundActivity::class.java)

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/JassRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/JassRoundActivity.kt
@@ -29,8 +29,10 @@ import com.github.lucaengel.jass_entials.data.cards.PlayerData
 import com.github.lucaengel.jass_entials.data.game_state.GameState
 import com.github.lucaengel.jass_entials.data.game_state.GameStateHolder
 import com.github.lucaengel.jass_entials.data.game_state.PlayerId
+import com.github.lucaengel.jass_entials.data.jass.JassType
 import com.github.lucaengel.jass_entials.game.JassComposables.Companion.CurrentTrick
 import com.github.lucaengel.jass_entials.game.player.DelayedCpuPlayer
+import com.github.lucaengel.jass_entials.game.postgame.CoiffeurPostRoundActivity
 import com.github.lucaengel.jass_entials.game.postgame.PostRoundActivity
 import com.github.lucaengel.jass_entials.ui.theme.JassentialsTheme
 
@@ -96,7 +98,11 @@ fun JassRound() {
             GameStateHolder.gameState = gameState
             GameStateHolder.players = players
 
-            val postGameActivity = Intent(context, PostRoundActivity::class.java)
+            val postGameActivity = if (gameState.jassType == JassType.COIFFEUR) {
+                Intent(context, CoiffeurPostRoundActivity::class.java)
+            } else {
+                Intent(context, PostRoundActivity::class.java)
+            }
             context.startActivity(postGameActivity)
         }
     }

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/SelectGameActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/SelectGameActivity.kt
@@ -124,6 +124,7 @@ fun SelectGameView(finishActivity: () -> Unit = {}) {
 //        println("made elems non null!!!")
 
 
+        GameStateHolder.prevRoundScores = listOf()
         when (gameType) {
             JassType.SCHIEBER -> {
                 GameStateHolder.bettingState = GameStateHolder.bettingState

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/player/CpuPlayer.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/player/CpuPlayer.kt
@@ -62,6 +62,10 @@ class CpuPlayer(
             && (Random.nextFloat() > 0.2 || bettingState.availableActions().size == 1)) {
 
             return CompletableFuture.completedFuture(bettingState.nextPlayer())
+
+        } else if (bettingState.availableBets().isEmpty()
+            || bettingState.availableTrumps().isEmpty()) {
+            return CompletableFuture.completedFuture(bettingState.nextPlayer())
         } else {
             return CompletableFuture.completedFuture(
                 bettingState.nextPlayer(

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
@@ -65,8 +65,8 @@ class DelayedCpuPlayer(
             CompletableFuture.runAsync {
                 Thread.sleep((if (bettingState.jassType == JassType.SIDI_BARRANI) 6 else 3) * threadSleepTime)
 
-                betFuture.complete(cpuPlayer.bet(bettingState, handCards).join())
             }
+                betFuture.complete(cpuPlayer.bet(bettingState, handCards).join())
         } else {
             // this is where tests run
             betFuture.complete(cpuPlayer.bet(bettingState, handCards).join())

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
@@ -38,7 +38,6 @@ class DelayedCpuPlayer(
                 sleepFuture.complete(null)
             }
             CompletableFuture.runAsync {
-//                Thread.sleep(threadSleepTime)
                 cardFuture.complete(cpuPlayer.cardToPlay(roundState, handCards).join())
 
             }

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/player/DelayedCpuPlayer.kt
@@ -59,14 +59,19 @@ class DelayedCpuPlayer(
     override fun bet(bettingState: BettingState, handCards: List<Card>): CompletableFuture<BettingState> {
         val betFuture = CompletableFuture<BettingState>()
 
+        betFuture.exceptionally { e ->
+            println("DelayedCpuPlayer.bet: exception = $e")
+            throw e
+        }
+
         // TODO: This is a temporary solution for testing to not have the cpu wait
         //  consider refactoring this to a more elegant solution
         if (GameStateHolder.runCpuAsynchronously) {
             CompletableFuture.runAsync {
                 Thread.sleep((if (bettingState.jassType == JassType.SIDI_BARRANI) 6 else 3) * threadSleepTime)
 
-            }
                 betFuture.complete(cpuPlayer.bet(bettingState, handCards).join())
+            }
         } else {
             // this is where tests run
             betFuture.complete(cpuPlayer.bet(bettingState, handCards).join())

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
@@ -35,6 +36,7 @@ import com.github.lucaengel.jass_entials.data.game_state.Score
 import com.github.lucaengel.jass_entials.data.game_state.TeamId
 import com.github.lucaengel.jass_entials.data.jass.Trump
 import com.github.lucaengel.jass_entials.game.SelectGameActivity
+import com.github.lucaengel.jass_entials.game.betting.CoiffeurBettingLogic
 import com.github.lucaengel.jass_entials.game.pregame.PreRoundBettingActivity
 import com.github.lucaengel.jass_entials.ui.theme.JassentialsTheme
 
@@ -73,7 +75,9 @@ fun CoiffeurScoreSheet() {
     val columnWidth = (rowWidth - (rowHeight * 3)) / 3
 
     Column(
-        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -138,7 +142,7 @@ fun CoiffeurScoreSheet() {
 
         val totalScore = roundScores.foldRight(Score.INITIAL) { (bet, score), acc ->
             val teamId = bet.playerId.teamId()
-            acc.withPointsAdded(teamId, score.roundPoints(teamId))
+            acc.withPointsAdded(teamId, score.roundPoints(teamId) * (bet.trump.ordinal + 1))
         }
         TrumpScoreRow(
             rowWidth = rowWidth,
@@ -214,19 +218,33 @@ fun TrumpScoreRow(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        Box(modifier = Modifier
-            .width(columnWidth)
-            .height(rowHeight)
-            .align(Alignment.CenterVertically)
-        ) {
+        Row (
+            modifier = Modifier
+                .width(columnWidth)
+                .height(rowHeight),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ){
             if (!isTotalPointsRow) {
-                Image(
-                    painter = painterResource(id = trump.asPicture()),
-                    contentDescription = trump.toString(),
+                Box(modifier = Modifier
+                    .width(rowHeight)
+                    .height(rowHeight)
+                    .align(Alignment.CenterVertically),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        painter = painterResource(id = trump.asPicture()),
+                        contentDescription = trump.toString(),
+                        modifier = Modifier
+                            .height(rowHeight),
+                        alignment = Alignment.Center,
+                    )
+                }
+
+                Text(
+                    text = " x ${CoiffeurBettingLogic.factorForTrump(trump)}",
                     modifier = Modifier
-                        .height(rowHeight)
-                        .align(Alignment.Center),
-                    alignment = Alignment.Center,
+                        .padding(5.dp, 0.dp, 0.dp, 0.dp),
                 )
             }
         }

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
@@ -208,7 +208,6 @@ fun TrumpScoreRow(
     roundScores: List<Pair<Bet, Score>>,
     isTotalPointsRow: Boolean = false,
 ) {
-
     Row (
         modifier = Modifier
             .width(rowWidth),

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
@@ -162,7 +162,7 @@ fun CoiffeurScoreSheet() {
                     .size == 2 * Trump.values().size
 
         if (isCoiffeurOver) {
-            val winningTeamId = gameState.roundState.winningTeam()
+            val winningTeamId = totalScore.winningTeam()
             val winnerText = if (winningTeamId != null) {
                 "$winningTeamId won!"
             } else {

--- a/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
+++ b/app/src/main/java/com/github/lucaengel/jass_entials/game/postgame/CoiffeurPostRoundActivity.kt
@@ -1,0 +1,235 @@
+package com.github.lucaengel.jass_entials.game.postgame
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.github.lucaengel.jass_entials.data.game_state.Bet
+import com.github.lucaengel.jass_entials.data.game_state.GameStateHolder
+import com.github.lucaengel.jass_entials.data.game_state.Score
+import com.github.lucaengel.jass_entials.data.game_state.TeamId
+import com.github.lucaengel.jass_entials.data.jass.JassType
+import com.github.lucaengel.jass_entials.data.jass.Trump
+import com.github.lucaengel.jass_entials.game.SelectGameActivity
+import com.github.lucaengel.jass_entials.game.pregame.PreRoundBettingActivity
+import com.github.lucaengel.jass_entials.ui.theme.JassentialsTheme
+
+class CoiffeurPostRoundActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            JassentialsTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    CoiffeurScoreSheet()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Composable for the Coiffeur score sheet.
+ */
+@Preview(device = Devices.AUTOMOTIVE_1024p, widthDp = 720, heightDp = 360)
+@Composable
+fun CoiffeurScoreSheet() {
+    val context = LocalContext.current
+
+    val gameState = GameStateHolder.gameState
+    val roundScores = GameStateHolder.prevRoundScores + (gameState.winningBet to gameState.roundState.score())
+    val bettingState = GameStateHolder.bettingState
+
+    val columnWidth = 100.dp
+    val rowHeight = 20.dp
+    val rowWidth = 300.dp + (rowHeight * 2)
+    Column(
+        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Row (
+            modifier = Modifier.width(rowWidth),
+            horizontalArrangement = Arrangement.Center,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = "Trump",
+                modifier = Modifier.width(columnWidth),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+
+//            Spacer(modifier = Modifier.weight(1f))
+
+            Divider(modifier = Modifier
+                .width(rowHeight)
+                .rotate(90f)
+                .align(Alignment.CenterVertically)
+            )
+
+//            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = gameState.currentUserId.teamId().name,
+                modifier = Modifier.width(columnWidth),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+
+//            Spacer(modifier = Modifier.weight(1f))
+
+            Divider(modifier = Modifier
+                .width(rowHeight)
+                .rotate(90f)
+                .align(Alignment.CenterVertically)
+            )
+
+//            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = gameState.currentUserId.nextPlayer().teamId().name,
+                modifier = Modifier.width(columnWidth),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+
+//            Spacer(modifier = Modifier.weight(1f))
+        }
+
+        Divider(modifier = Modifier.width(rowWidth))
+
+        Trump.values().map { trump ->
+
+            TrumpScoreRow(
+                rowWidth = rowWidth,
+                rowHeight = rowHeight,
+                columnWidth = columnWidth,
+                trump = trump,
+                leftTeam = gameState.currentUserId.teamId(),
+                roundScores = roundScores.filter { it.first.trump == trump }
+            )
+
+            Divider(modifier = Modifier.width(rowWidth))
+        }
+
+        val isSidiBarraniOver = gameState.jassType == JassType.SIDI_BARRANI && (
+                (GameStateHolder.pointLimits[JassType.SIDI_BARRANI] ?: 1000) <= gameState.roundState.score().gamePoints(TeamId.TEAM_1)
+                        || (GameStateHolder.pointLimits[JassType.SIDI_BARRANI] ?: 1000) <= gameState.roundState.score().gamePoints(TeamId.TEAM_2)
+                )
+
+        if (isSidiBarraniOver) {
+            val winningTeamId = gameState.roundState.winningTeam()
+            val winnerText = if (winningTeamId != null) {
+                "$winningTeamId won the game!"
+            } else {
+                "it was a draw!"
+            }
+
+            Text(text = "The game is over, $winnerText")
+            Button(
+                onClick = {
+                    val intent = Intent(context, SelectGameActivity::class.java)
+                    context.startActivity(intent)
+                }
+            ) {
+                Text(text = "Choose a new Jass game")
+            }
+
+        } else {
+            Button(
+                onClick = {
+                    // have player to the right of the starting better of the last round start the next round
+                    GameStateHolder.goToNextBettingStateRound(bettingState.startingBetterId.nextPlayer())
+
+                    val intent = Intent(context, PreRoundBettingActivity::class.java)
+                    context.startActivity(intent)
+                }
+            ) {
+                Text(text = "Start next round")
+            }
+        }
+    }
+}
+
+/**
+ * Composable for the score sheet.
+ */
+@Composable
+fun TrumpScoreRow(
+    rowWidth: Dp,
+    rowHeight: Dp,
+    columnWidth: Dp,
+    trump: Trump,
+    leftTeam: TeamId,
+    roundScores: List<Pair<Bet, Score>>
+) {
+    Row (
+        modifier = Modifier
+            .width(rowWidth),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+
+        Box(modifier = Modifier
+            .width(columnWidth)
+            .height(rowHeight)
+            .align(Alignment.CenterVertically)
+        ) {
+            Image(
+                painter = painterResource(id = trump.asPicture()),
+                contentDescription = trump.toString(),
+                modifier = Modifier
+                    .height(rowHeight)
+                    .align(Alignment.Center),
+//                    .align(Alignment.CenterVertically),
+                alignment = Alignment.Center,
+            )
+        }
+
+        Divider(modifier = Modifier
+            .width(rowHeight)
+            .rotate(90f)
+            .align(Alignment.CenterVertically)
+        )
+
+        Text(text = roundScores.firstOrNull { it.first.playerId.teamId() == leftTeam }?.second?.gamePoints(leftTeam)?.toString() ?: "---",
+            modifier = Modifier.width(columnWidth),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+
+        Divider(modifier = Modifier
+            .width(rowHeight)
+            .rotate(90f)
+            .align(Alignment.CenterVertically)
+        )
+
+        Text(text = roundScores.firstOrNull { it.first.playerId.teamId() != leftTeam }?.second?.gamePoints(leftTeam.otherTeam())?.toString() ?: "---",
+            modifier = Modifier.width(columnWidth),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+    }
+}


### PR DESCRIPTION
This PR adapts the Coiffeur post-round interface:

- Table view of all the trumps and how many points each team made with the given trump
- Total points calculated with the multiplication factor of the given trump
- Both landscape and vertical mode supported

<div>
<img src="https://github.com/apps-entials/jass-entials/assets/71313761/a4d93555-8ed2-4386-ada5-3f02db0dfd73" />
<img src="https://github.com/apps-entials/jass-entials/assets/71313761/36d22ced-71cf-403c-b078-854e8f517e37" height="600" />
</div>


